### PR TITLE
[Feature] 디자인 시스템 - TextField, ErrorCaption

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,6 +30,7 @@ android {
 dependencies {
     // feature
     implementation(projects.feature.home)
+    implementation(projects.core.designsystem)
 //    implementation(projects.feature.profile)
 //    implementation(projects.feature.match)
 

--- a/app/src/main/java/com/moya/funch/MainActivity.kt
+++ b/app/src/main/java/com/moya/funch/MainActivity.kt
@@ -10,7 +10,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import com.moya.funch.ui.theme.FunchAOSTheme
+import com.moya.funch.theme.FunchTheme
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -18,13 +18,13 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            FunchAOSTheme {
+            FunchTheme {
                 // A surface container using the 'background' color from the theme
                 Surface(
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background,
                 ) {
-                    Greeting("Android")
+                    Greeting(name = "Android")
                 }
             }
         }
@@ -45,7 +45,7 @@ fun Greeting(
 @Preview(showBackground = true)
 @Composable
 fun GreetingPreview() {
-    FunchAOSTheme {
+    FunchTheme {
         Greeting("Android")
     }
 }

--- a/core/designsystem/src/main/java/com/moya/funch/component/FunchCaption.kt
+++ b/core/designsystem/src/main/java/com/moya/funch/component/FunchCaption.kt
@@ -1,0 +1,61 @@
+package com.moya.funch.component
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.moya.funch.icon.FunchIconAsset
+import com.moya.funch.theme.Coral500
+import com.moya.funch.theme.FunchTheme
+
+@Composable
+fun FunchErrorCaption(
+    isError: Boolean = false,
+    errorText: String,
+    description: String = "",
+) {
+    if (isError) {
+        Row(
+            modifier = Modifier
+                .wrapContentSize()
+                .padding(top = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                modifier = Modifier.padding(start = 8.dp, end = 4.dp),
+                painter = painterResource(id = FunchIconAsset.Etc.information_24),
+                contentDescription = description,
+                tint = Coral500,
+            )
+            Text(
+                text = errorText,
+                color = Coral500,
+                style = FunchTheme.typography.caption,
+            )
+        }
+    }
+}
+
+/*============================== Preview =================================*/
+
+@Preview("ErrorCaption", showBackground = true, backgroundColor = 0xFF2C2C2C)
+@Composable
+fun FunchErrorCaptionPreview() {
+    val isError = remember { mutableStateOf(true) }
+
+    FunchTheme {
+        FunchErrorCaption(
+            isError = isError.value,
+            errorText = "errorText",
+        )
+    }
+}

--- a/core/designsystem/src/main/java/com/moya/funch/component/FunchIconButton.kt
+++ b/core/designsystem/src/main/java/com/moya/funch/component/FunchIconButton.kt
@@ -22,7 +22,7 @@ import com.moya.funch.theme.Gray400
 import com.moya.funch.theme.Gray500
 import com.moya.funch.theme.Yellow500
 
-data class IconType(
+data class FunchIcon(
     @DrawableRes val resId: Int,
     val description: String,
     val tint: Color,
@@ -32,7 +32,7 @@ data class IconType(
 fun FunchIconLargeButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    iconType: IconType,
+    funchIcon: FunchIcon,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
 
@@ -48,9 +48,9 @@ fun FunchIconLargeButton(
             ),
     ) {
         Icon(
-            painter = painterResource(id = iconType.resId),
-            contentDescription = iconType.description,
-            tint = iconType.tint,
+            painter = painterResource(id = funchIcon.resId),
+            contentDescription = funchIcon.description,
+            tint = funchIcon.tint,
         )
     }
 }
@@ -59,7 +59,7 @@ fun FunchIconLargeButton(
 fun FunchIconButton(
     modifier: Modifier = Modifier,
     onClick: () -> Unit,
-    iconType: IconType,
+    funchIcon: FunchIcon,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
 
@@ -69,9 +69,9 @@ fun FunchIconButton(
             indication = null,
             interactionSource = interactionSource,
         ),
-        painter = painterResource(id = iconType.resId),
-        contentDescription = iconType.description,
-        tint = iconType.tint,
+        painter = painterResource(id = funchIcon.resId),
+        contentDescription = funchIcon.description,
+        tint = funchIcon.tint,
     )
 }
 
@@ -85,7 +85,7 @@ fun FunchLargeIconButtonPreview() {
             color = Gray500, shape = RoundedCornerShape(12.dp)
         ),
         onClick = { /*TODO*/ },
-        iconType = IconType(
+        funchIcon = FunchIcon(
             resId = FunchIconAsset.Search.search_24,
             description = "",
             tint = Yellow500,
@@ -98,7 +98,7 @@ fun FunchLargeIconButtonPreview() {
 fun FunchMediumIconButtonPreview() {
     FunchIconButton(
         onClick = { /*TODO*/ },
-        iconType = IconType(
+        funchIcon = FunchIcon(
             resId = FunchIconAsset.Search.search_24,
             description = "",
             tint = Gray400,
@@ -111,7 +111,7 @@ fun FunchMediumIconButtonPreview() {
 fun FunchSmallIconButtonPreview() {
     FunchIconButton(
         onClick = { /*TODO*/ },
-        iconType = IconType(
+        funchIcon = FunchIcon(
             resId = FunchIconAsset.Search.search_16,
             description = "",
             tint = Gray400,

--- a/core/designsystem/src/main/java/com/moya/funch/component/FunchIconButton.kt
+++ b/core/designsystem/src/main/java/com/moya/funch/component/FunchIconButton.kt
@@ -22,13 +22,17 @@ import com.moya.funch.theme.Gray400
 import com.moya.funch.theme.Gray500
 import com.moya.funch.theme.Yellow500
 
+data class IconType(
+    @DrawableRes val resId: Int,
+    val description: String,
+    val tint: Color,
+)
+
 @Composable
 fun FunchIconLargeButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    @DrawableRes resId: Int,
-    description: String = "",
-    tint: Color,
+    iconType: IconType,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
 
@@ -44,20 +48,18 @@ fun FunchIconLargeButton(
             ),
     ) {
         Icon(
-            painter = painterResource(id = resId),
-            contentDescription = description,
-            tint = tint,
+            painter = painterResource(id = iconType.resId),
+            contentDescription = iconType.description,
+            tint = iconType.tint,
         )
     }
 }
 
 @Composable
 fun FunchIconButton(
-    onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    @DrawableRes resId: Int,
-    description: String = "",
-    tint: Color,
+    onClick: () -> Unit,
+    iconType: IconType,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
 
@@ -67,24 +69,27 @@ fun FunchIconButton(
             indication = null,
             interactionSource = interactionSource,
         ),
-        painter = painterResource(id = resId),
-        contentDescription = description,
-        tint = tint,
+        painter = painterResource(id = iconType.resId),
+        contentDescription = iconType.description,
+        tint = iconType.tint,
     )
 }
 
-/*========================== PREVIEW =================================*/
+/*============================== Preview =================================*/
 
 @Preview(showBackground = true, backgroundColor = 0xFF2C2C2C)
 @Composable
 fun FunchLargeIconButtonPreview() {
     FunchIconLargeButton(
-        onClick = { /*TODO*/ },
-        resId = FunchIconAsset.Search.search_24,
         modifier = Modifier.background(
             color = Gray500, shape = RoundedCornerShape(12.dp)
         ),
-        tint = Yellow500,
+        onClick = { /*TODO*/ },
+        iconType = IconType(
+            resId = FunchIconAsset.Search.search_24,
+            description = "",
+            tint = Yellow500,
+        ),
     )
 }
 
@@ -93,8 +98,11 @@ fun FunchLargeIconButtonPreview() {
 fun FunchMediumIconButtonPreview() {
     FunchIconButton(
         onClick = { /*TODO*/ },
-        resId = FunchIconAsset.Search.search_24,
-        tint = Gray400,
+        iconType = IconType(
+            resId = FunchIconAsset.Search.search_24,
+            description = "",
+            tint = Gray400,
+        ),
     )
 }
 
@@ -103,7 +111,10 @@ fun FunchMediumIconButtonPreview() {
 fun FunchSmallIconButtonPreview() {
     FunchIconButton(
         onClick = { /*TODO*/ },
-        resId = FunchIconAsset.Search.search_16,
-        tint = Gray400,
+        iconType = IconType(
+            resId = FunchIconAsset.Search.search_16,
+            description = "",
+            tint = Gray400,
+        ),
     )
 }

--- a/core/designsystem/src/main/java/com/moya/funch/component/FunchIconButton.kt
+++ b/core/designsystem/src/main/java/com/moya/funch/component/FunchIconButton.kt
@@ -1,18 +1,22 @@
 package com.moya.funch.component
 
 import androidx.annotation.DrawableRes
+import androidx.compose.foundation.Indication
+import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -29,23 +33,28 @@ data class FunchIcon(
 )
 
 @Composable
-fun FunchIconLargeButton(
-    onClick: () -> Unit,
+fun FunchIconButton(
     modifier: Modifier = Modifier,
+    onClick: () -> Unit,
     funchIcon: FunchIcon,
+    backgroundColor: Color = Color.Transparent,
+    roundedCornerShape: RoundedCornerShape = RoundedCornerShape(0.dp),
+    indication: Indication? = LocalIndication.current,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ) {
-    val interactionSource = remember { MutableInteractionSource() }
-
     Box(
-        contentAlignment = Alignment.Center,
         modifier = modifier
-            .size(40.dp)
-            .padding(8.dp)
+            .background(
+                color = backgroundColor,
+                shape = roundedCornerShape,
+            )
+            .clip(roundedCornerShape)
             .clickable(
                 onClick = onClick,
-                indication = null,
+                indication = indication,
                 interactionSource = interactionSource,
             ),
+        contentAlignment = Alignment.Center,
     ) {
         Icon(
             painter = painterResource(id = funchIcon.resId),
@@ -55,35 +64,15 @@ fun FunchIconLargeButton(
     }
 }
 
-@Composable
-fun FunchIconButton(
-    modifier: Modifier = Modifier,
-    onClick: () -> Unit,
-    funchIcon: FunchIcon,
-) {
-    val interactionSource = remember { MutableInteractionSource() }
-
-    Icon(
-        modifier = modifier.clickable(
-            onClick = onClick,
-            indication = null,
-            interactionSource = interactionSource,
-        ),
-        painter = painterResource(id = funchIcon.resId),
-        contentDescription = funchIcon.description,
-        tint = funchIcon.tint,
-    )
-}
-
 /*============================== Preview =================================*/
 
-@Preview(showBackground = true, backgroundColor = 0xFF2C2C2C)
+@Preview("Icon Large Button", showBackground = true, backgroundColor = 0xFFFFFF)
 @Composable
 fun FunchLargeIconButtonPreview() {
-    FunchIconLargeButton(
-        modifier = Modifier.background(
-            color = Gray500, shape = RoundedCornerShape(12.dp)
-        ),
+    FunchIconButton(
+        modifier = Modifier.size(40.dp),
+        roundedCornerShape = RoundedCornerShape(12.dp),
+        backgroundColor = Gray500,
         onClick = { /*TODO*/ },
         funchIcon = FunchIcon(
             resId = FunchIconAsset.Search.search_24,
@@ -93,7 +82,7 @@ fun FunchLargeIconButtonPreview() {
     )
 }
 
-@Preview(showBackground = true)
+@Preview("Icon Medium Button", showBackground = true)
 @Composable
 fun FunchMediumIconButtonPreview() {
     FunchIconButton(
@@ -106,7 +95,7 @@ fun FunchMediumIconButtonPreview() {
     )
 }
 
-@Preview(showBackground = true)
+@Preview("Icon Small Button", showBackground = true)
 @Composable
 fun FunchSmallIconButtonPreview() {
     FunchIconButton(
@@ -116,5 +105,6 @@ fun FunchSmallIconButtonPreview() {
             description = "",
             tint = Gray400,
         ),
+        indication = null,
     )
 }

--- a/core/designsystem/src/main/java/com/moya/funch/component/FunchTextField.kt
+++ b/core/designsystem/src/main/java/com/moya/funch/component/FunchTextField.kt
@@ -203,7 +203,7 @@ fun FunchTextFieldIconType(
     value: String,
     onValueChange: (String) -> Unit,
     hint: String,
-    iconType: IconType,
+    iconType: FunchIcon,
     isError: Boolean = false,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     isFocus: Boolean = interactionSource.collectIsFocusedAsState().value,
@@ -280,7 +280,7 @@ fun FunchTextFieldButtonType(
     onValueChange: (String) -> Unit,
     hint: String,
     buttonBackGround: Color,
-    iconType: IconType,
+    funchIcon: FunchIcon,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     isFocus: Boolean = interactionSource.collectIsFocusedAsState().value,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
@@ -340,7 +340,7 @@ fun FunchTextFieldButtonType(
                             shape = RoundedCornerShape(12.dp)
                         ),
                     onClick = onClick,
-                    iconType = iconType,
+                    funchIcon = funchIcon,
                 )
             }
         }
@@ -461,7 +461,7 @@ fun FunchTextFieldIconTypePreview() {
                 value = text,
                 onValueChange = { innerText -> text = innerText },
                 hint = "가까운 지하철역 검색",
-                iconType = IconType(
+                iconType = FunchIcon(
                     resId = FunchIconAsset.Search.search_24,
                     description = "",
                     tint = Gray500
@@ -489,7 +489,7 @@ fun FunchTextFieldButtonTypePreview() {
                 value = text,
                 onValueChange = { innerText -> text = innerText },
                 hint = "친구 코드를 입력하고 매칭하기",
-                iconType = IconType(
+                funchIcon = FunchIcon(
                     resId = FunchIconAsset.Search.search_24,
                     description = "",
                     tint = Yellow500

--- a/core/designsystem/src/main/java/com/moya/funch/component/FunchTextField.kt
+++ b/core/designsystem/src/main/java/com/moya/funch/component/FunchTextField.kt
@@ -1,0 +1,505 @@
+package com.moya.funch.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.moya.funch.icon.FunchIconAsset
+import com.moya.funch.theme.Coral500
+import com.moya.funch.theme.FunchTheme
+import com.moya.funch.theme.Gray400
+import com.moya.funch.theme.Gray500
+import com.moya.funch.theme.Gray800
+import com.moya.funch.theme.White
+import com.moya.funch.theme.Yellow500
+
+@Composable
+fun FunchTextFieldDefaultType(
+    modifier: Modifier = Modifier,
+    value: String,
+    onValueChange: (String) -> Unit,
+    hint: String,
+    isError: Boolean = false,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    isFocus: Boolean = interactionSource.collectIsFocusedAsState().value,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+) {
+    BasicTextField(
+        modifier = modifier,
+        value = value,
+        onValueChange = onValueChange,
+        singleLine = true,
+        textStyle = TextStyle(
+            color = White,
+            fontSize = FunchTheme.typography.b.fontSize,
+            lineHeight = FunchTheme.typography.b.lineHeight,
+            fontFamily = FunchTheme.typography.b.fontFamily,
+            fontWeight = FunchTheme.typography.b.fontWeight,
+        ),
+        cursorBrush = SolidColor(Color(0xFF0074FF)),
+        keyboardOptions = keyboardOptions,
+        keyboardActions = keyboardActions,
+        interactionSource = interactionSource,
+        decorationBox = { innerTextField ->
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+                    .background(Gray800, RoundedCornerShape(16.dp))
+                    .then(
+                        if (isFocus)
+                            Modifier.border(
+                                width = 1.dp,
+                                color = Color.White,
+                                shape = RoundedCornerShape(16.dp)
+                            )
+                        else if (isError)
+                            Modifier.border(
+                                width = 1.dp,
+                                color = Coral500,
+                                shape = RoundedCornerShape(16.dp)
+                            )
+                        else Modifier
+                    )
+                    .padding(horizontal = 16.dp),
+                contentAlignment = Alignment.CenterStart,
+            ) {
+                if (value.isEmpty()) {
+                    Text(
+                        text = hint,
+                        color = Gray400,
+                        fontSize = 14.sp,
+                        style = FunchTheme.typography.b,
+                    )
+                }
+                innerTextField()
+            }
+        }
+    )
+}
+
+@Composable
+fun FunchTextFieldMaxLengthType(
+    modifier: Modifier = Modifier,
+    value: String,
+    onValueChange: (String) -> Unit,
+    maxLength: Int,
+    hint: String,
+    isError: Boolean = false,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    isFocus: Boolean = interactionSource.collectIsFocusedAsState().value,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+) {
+    BasicTextField(
+        modifier = modifier,
+        value = value,
+        onValueChange = onValueChange,
+        singleLine = true,
+        textStyle = TextStyle(
+            color = White,
+            fontSize = FunchTheme.typography.b.fontSize,
+            lineHeight = FunchTheme.typography.b.lineHeight,
+            fontFamily = FunchTheme.typography.b.fontFamily,
+            fontWeight = FunchTheme.typography.b.fontWeight,
+        ),
+        cursorBrush = SolidColor(Color(0xFF0074FF)),
+        keyboardOptions = keyboardOptions,
+        keyboardActions = keyboardActions,
+        interactionSource = interactionSource,
+        decorationBox = { innerTextField ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+                    .background(Gray800, RoundedCornerShape(16.dp))
+                    .then(
+                        if (isFocus)
+                            Modifier.border(
+                                width = 1.dp,
+                                color = Color.White,
+                                shape = RoundedCornerShape(16.dp)
+                            )
+                        else if (isError)
+                            Modifier.border(
+                                width = 1.dp,
+                                color = Coral500,
+                                shape = RoundedCornerShape(16.dp)
+                            )
+                        else Modifier
+                    )
+                    .padding(horizontal = 16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Box {
+                    if (value.isEmpty()) {
+                        Text(
+                            text = hint,
+                            color = Gray400,
+                            fontSize = 14.sp,
+                            style = FunchTheme.typography.b,
+                        )
+                    }
+                    innerTextField()
+                }
+
+                Text(
+                    text = annotatedStringMaxLengthType(
+                        isError = isError,
+                        value = value,
+                        maxLength = maxLength
+                    ),
+                    style = TextStyle(
+                        fontSize = 14.sp,
+                        lineHeight = FunchTheme.typography.b.lineHeight,
+                        fontFamily = FunchTheme.typography.b.fontFamily,
+                        fontWeight = FunchTheme.typography.b.fontWeight,
+                    ),
+                )
+            }
+        }
+    )
+}
+
+@Composable
+fun FunchTextFieldIconType(
+    modifier: Modifier = Modifier,
+    value: String,
+    onValueChange: (String) -> Unit,
+    hint: String,
+    iconType: IconType,
+    isError: Boolean = false,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    isFocus: Boolean = interactionSource.collectIsFocusedAsState().value,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+) {
+    BasicTextField(
+        modifier = modifier,
+        value = value,
+        onValueChange = onValueChange,
+        singleLine = true,
+        textStyle = TextStyle(
+            color = White,
+            fontSize = FunchTheme.typography.b.fontSize,
+            lineHeight = FunchTheme.typography.b.lineHeight,
+            fontFamily = FunchTheme.typography.b.fontFamily,
+            fontWeight = FunchTheme.typography.b.fontWeight,
+        ),
+        cursorBrush = SolidColor(Color(0xFF0074FF)),
+        keyboardOptions = keyboardOptions,
+        keyboardActions = keyboardActions,
+        interactionSource = interactionSource,
+        decorationBox = { innerTextField ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+                    .background(Gray800, RoundedCornerShape(16.dp))
+                    .then(
+                        if (isFocus)
+                            Modifier.border(
+                                width = 1.dp,
+                                color = Color.White,
+                                shape = RoundedCornerShape(16.dp)
+                            )
+                        else if (isError)
+                            Modifier.border(
+                                width = 1.dp,
+                                color = Coral500,
+                                shape = RoundedCornerShape(16.dp)
+                            )
+                        else Modifier
+                    )
+                    .padding(horizontal = 16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    painter = painterResource(id = iconType.resId),
+                    contentDescription = iconType.description,
+                    tint = iconType.tint,
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Box {
+                    if (value.isEmpty()) {
+                        Text(
+                            text = hint,
+                            color = Gray400,
+                            fontSize = 14.sp,
+                            style = FunchTheme.typography.b,
+                        )
+                    }
+                    innerTextField()
+                }
+            }
+        }
+    )
+}
+
+@Composable
+fun FunchTextFieldButtonType(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+    value: String,
+    onValueChange: (String) -> Unit,
+    hint: String,
+    buttonBackGround: Color,
+    iconType: IconType,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    isFocus: Boolean = interactionSource.collectIsFocusedAsState().value,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+) {
+    BasicTextField(
+        modifier = modifier,
+        value = value,
+        onValueChange = onValueChange,
+        singleLine = true,
+        textStyle = TextStyle(
+            color = White,
+            fontSize = FunchTheme.typography.b.fontSize,
+            lineHeight = FunchTheme.typography.b.lineHeight,
+            fontFamily = FunchTheme.typography.b.fontFamily,
+            fontWeight = FunchTheme.typography.b.fontWeight,
+        ),
+        cursorBrush = SolidColor(Color(0xFF0074FF)),
+        keyboardOptions = keyboardOptions,
+        keyboardActions = keyboardActions,
+        interactionSource = interactionSource,
+        decorationBox = { innerTextField ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+                    .background(Gray800, RoundedCornerShape(16.dp))
+                    .then(
+                        if (isFocus)
+                            Modifier.border(
+                                width = 1.dp,
+                                color = Color.White,
+                                shape = RoundedCornerShape(16.dp)
+                            )
+                        else Modifier
+                    )
+                    .padding(start = 16.dp, end = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Box(modifier = Modifier.weight(1f)) {
+                    if (value.isEmpty()) {
+                        Text(
+                            text = hint,
+                            color = Gray400,
+                            fontSize = 14.sp,
+                            style = FunchTheme.typography.b,
+                        )
+                    }
+                    innerTextField()
+                }
+                Spacer(modifier = Modifier.width(8.dp))
+                FunchIconLargeButton(
+                    modifier = Modifier
+                        .background(
+                            color = buttonBackGround,
+                            shape = RoundedCornerShape(12.dp)
+                        ),
+                    onClick = onClick,
+                    iconType = iconType,
+                )
+            }
+        }
+    )
+}
+
+private fun annotatedStringMaxLengthType(
+    isError: Boolean,
+    value: String,
+    maxLength: Int,
+) = buildAnnotatedString {
+    if (!isError) {
+        if (value.isEmpty()) {
+            withStyle(style = SpanStyle(color = Gray400)) {
+                append("${value.length}/${maxLength}")
+            }
+        } else {
+            withStyle(style = SpanStyle(color = White)) {
+                append("${value.length}")
+            }
+            withStyle(style = SpanStyle(color = Gray400)) {
+                append("/${maxLength}")
+            }
+        }
+    } else {
+        withStyle(style = SpanStyle(color = Coral500)) {
+            append("${value.length}/${maxLength}")
+        }
+    }
+}
+
+/*============================== Preview =================================*/
+
+@Preview("Default", showBackground = true, backgroundColor = 0xFF2C2C2C)
+@Composable
+fun FunchTextFieldDefaultTypePreview() {
+    var text by remember { mutableStateOf("") }
+    val isError = remember { mutableStateOf(false) }
+    val maxLength = 9
+
+    LaunchedEffect(text) {
+        if (text.length < maxLength) {
+            isError.value = false
+        }
+    }
+
+    FunchTheme {
+        Column {
+            FunchTextFieldDefaultType(
+                value = text,
+                onValueChange = { innerText -> text = innerText },
+                hint = "최대 ${maxLength}글자",
+                isError = isError.value,
+            )
+            FunchErrorCaption(
+                isError = isError.value,
+                errorText = "errorText",
+            )
+            Button(
+                onClick = { isError.value = text.length > maxLength },
+            ) {
+                Text(text = "전송")
+            }
+        }
+    }
+}
+
+@Preview("MaxLengthType", showBackground = true, backgroundColor = 0xFF2C2C2C)
+@Composable
+fun FunchTextFieldMaxLengthTypePreview() {
+    var text by remember { mutableStateOf("") }
+    val isError = remember { mutableStateOf(false) }
+    val interactionSource = remember { MutableInteractionSource() }
+    val isFocused by interactionSource.collectIsFocusedAsState()
+    val maxLength = 9
+
+    LaunchedEffect(isFocused) {
+        if (!isFocused || text.length < maxLength) {
+            isError.value = false
+        }
+    }
+
+    FunchTheme {
+        Column {
+            FunchTextFieldMaxLengthType(
+                value = text,
+                onValueChange = { innerText ->
+                    if (innerText.length <= maxLength) {
+                        text = innerText
+                        isError.value = false
+                    } else {
+                        isError.value = true
+                    }
+                },
+                maxLength = maxLength,
+                hint = "최대 ${maxLength}글자",
+                isError = isError.value,
+                interactionSource = interactionSource,
+                isFocus = isFocused,
+            )
+            FunchErrorCaption(
+                isError = isError.value,
+                errorText = if (isError.value) "최대 ${maxLength}글자까지 입력할 수 있어요" else "",
+            )
+        }
+    }
+}
+
+@Preview("Icon", showBackground = true, backgroundColor = 0xFF2C2C2C)
+@Composable
+fun FunchTextFieldIconTypePreview() {
+    var text by remember { mutableStateOf("") }
+    val isError = remember { mutableStateOf(false) }
+
+    FunchTheme {
+        Column {
+            FunchTextFieldIconType(
+                value = text,
+                onValueChange = { innerText -> text = innerText },
+                hint = "가까운 지하철역 검색",
+                iconType = IconType(
+                    resId = FunchIconAsset.Search.search_24,
+                    description = "",
+                    tint = Gray500
+                ),
+                isError = isError.value,
+            )
+            FunchErrorCaption(
+                isError = isError.value,
+                errorText = "존재하지 않는 지하철역이에요",
+            )
+        }
+    }
+}
+
+@Preview("Button", showBackground = true, backgroundColor = 0xFF2C2C2C)
+@Composable
+fun FunchTextFieldButtonTypePreview() {
+    var text by remember { mutableStateOf("") }
+    val isError = remember { mutableStateOf(false) }
+
+    FunchTheme {
+        Column {
+            FunchTextFieldButtonType(
+                onClick = { /*TODO*/ },
+                value = text,
+                onValueChange = { innerText -> text = innerText },
+                hint = "친구 코드를 입력하고 매칭하기",
+                iconType = IconType(
+                    resId = FunchIconAsset.Search.search_24,
+                    description = "",
+                    tint = Yellow500
+                ),
+                buttonBackGround = Gray500,
+            )
+            FunchErrorCaption(
+                isError = isError.value,
+                errorText = "존재하지 않는 지하철역이에요",
+            )
+        }
+    }
+}

--- a/core/designsystem/src/main/java/com/moya/funch/component/TextField.kt
+++ b/core/designsystem/src/main/java/com/moya/funch/component/TextField.kt
@@ -48,7 +48,7 @@ import com.moya.funch.theme.White
 import com.moya.funch.theme.Yellow500
 
 @Composable
-fun FunchTextFieldDefaultType(
+fun FunchDefaultTextField(
     modifier: Modifier = Modifier,
     value: String,
     onValueChange: (String) -> Unit,
@@ -114,7 +114,7 @@ fun FunchTextFieldDefaultType(
 }
 
 @Composable
-fun FunchTextFieldMaxLengthType(
+fun FunchMaxLengthTextField(
     modifier: Modifier = Modifier,
     value: String,
     onValueChange: (String) -> Unit,
@@ -198,7 +198,7 @@ fun FunchTextFieldMaxLengthType(
 }
 
 @Composable
-fun FunchTextFieldIconType(
+fun FunchIconTextField(
     modifier: Modifier = Modifier,
     value: String,
     onValueChange: (String) -> Unit,
@@ -273,7 +273,7 @@ fun FunchTextFieldIconType(
 }
 
 @Composable
-fun FunchTextFieldButtonType(
+fun FunchButtonTextField(
     modifier: Modifier = Modifier,
     onClick: () -> Unit,
     value: String,
@@ -389,7 +389,7 @@ fun FunchTextFieldDefaultTypePreview() {
 
     FunchTheme {
         Column {
-            FunchTextFieldDefaultType(
+            FunchDefaultTextField(
                 value = text,
                 onValueChange = { innerText -> text = innerText },
                 hint = "최대 ${maxLength}글자",
@@ -425,7 +425,7 @@ fun FunchTextFieldMaxLengthTypePreview() {
 
     FunchTheme {
         Column {
-            FunchTextFieldMaxLengthType(
+            FunchMaxLengthTextField(
                 value = text,
                 onValueChange = { innerText ->
                     if (innerText.length <= maxLength) {
@@ -457,7 +457,7 @@ fun FunchTextFieldIconTypePreview() {
 
     FunchTheme {
         Column {
-            FunchTextFieldIconType(
+            FunchIconTextField(
                 value = text,
                 onValueChange = { innerText -> text = innerText },
                 hint = "가까운 지하철역 검색",
@@ -484,7 +484,7 @@ fun FunchTextFieldButtonTypePreview() {
 
     FunchTheme {
         Column {
-            FunchTextFieldButtonType(
+            FunchButtonTextField(
                 onClick = { /*TODO*/ },
                 value = text,
                 onValueChange = { innerText -> text = innerText },

--- a/core/designsystem/src/main/java/com/moya/funch/component/TextField.kt
+++ b/core/designsystem/src/main/java/com/moya/funch/component/TextField.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
@@ -275,12 +276,10 @@ fun FunchIconTextField(
 @Composable
 fun FunchButtonTextField(
     modifier: Modifier = Modifier,
-    onClick: () -> Unit,
     value: String,
     onValueChange: (String) -> Unit,
     hint: String,
-    buttonBackGround: Color,
-    funchIcon: FunchIcon,
+    iconButton: @Composable () -> Unit,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     isFocus: Boolean = interactionSource.collectIsFocusedAsState().value,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
@@ -333,15 +332,7 @@ fun FunchButtonTextField(
                     innerTextField()
                 }
                 Spacer(modifier = Modifier.width(8.dp))
-                FunchIconLargeButton(
-                    modifier = Modifier
-                        .background(
-                            color = buttonBackGround,
-                            shape = RoundedCornerShape(12.dp)
-                        ),
-                    onClick = onClick,
-                    funchIcon = funchIcon,
-                )
+                iconButton()
             }
         }
     )
@@ -485,16 +476,22 @@ fun FunchTextFieldButtonTypePreview() {
     FunchTheme {
         Column {
             FunchButtonTextField(
-                onClick = { /*TODO*/ },
                 value = text,
                 onValueChange = { innerText -> text = innerText },
                 hint = "친구 코드를 입력하고 매칭하기",
-                funchIcon = FunchIcon(
-                    resId = FunchIconAsset.Search.search_24,
-                    description = "",
-                    tint = Yellow500
-                ),
-                buttonBackGround = Gray500,
+                iconButton = {
+                    FunchIconButton(
+                        modifier = Modifier.size(40.dp),
+                        backgroundColor = Gray500,
+                        onClick = { /*TODO*/ },
+                        roundedCornerShape = RoundedCornerShape(12.dp),
+                        funchIcon = FunchIcon(
+                            resId = FunchIconAsset.Search.search_24,
+                            description = "",
+                            tint = Yellow500,
+                        ),
+                    )
+                }
             )
             FunchErrorCaption(
                 isError = isError.value,


### PR DESCRIPTION
## 관련 이슈
- closed #6 

## 작업한 내용
- [x] : FunchTextField 4종 구현
- [x] : FunchErrorCaption 구현

## PR 포인트
- `enum class`로 텍스트 필드 분기처리를 시도하려 하였지만, 디자인에 나와있는 텍스트 필드 명칭(default, maxLength, icon, button)을 사용하여 각각의 컴포저블 함수로 구분하였습니다.
- `IconType` 객체를 통해 Icon의 속성을 구분합니다.
```
data class IconType(
    @DrawableRes val resId: Int,
    val description: String,
    val tint: Color,
)
```
- `IconType` 객체는 현재 `FunchIconButton()`, `FunchIconLargeButton()`, `FunchTextFieldButtonType()` 에서 사용됩니다.

![image](https://github.com/Nexters/Funch-AOS/assets/54674781/0c771700-fa1b-421b-a3ab-1734ff2364c5)
![image](https://github.com/Nexters/Funch-AOS/assets/54674781/1fc9003a-b868-4e68-a438-ec6f1909d81b)

