### PR TITLE
[fix] data모듈 Result.map() -> Result.mapCatching으로 수정, dataStore DeviceId : USER_ID -> DeviceID로 수정

### DIFF
--- a/core/data/src/main/java/com/moya/funch/datasource/local/LocalUserDataSourceImpl.kt
+++ b/core/data/src/main/java/com/moya/funch/datasource/local/LocalUserDataSourceImpl.kt
@@ -10,6 +10,7 @@ class LocalUserDataSourceImpl @Inject constructor(
 ) : LocalUserDataSource {
 
     override suspend fun fetchUserProfile(): Result<ProfileModel> {
+//        userDataStore.clear() 여기 부분 주석 해제하고 한 번 빌드돌리면 데이터가 초기화됩니다!!
         if (userDataStore.hasUserId()) {
             return Result.success(
                 ProfileModel(

--- a/core/data/src/main/java/com/moya/funch/datasource/remote/RemoteMatchDataSourceImpl.kt
+++ b/core/data/src/main/java/com/moya/funch/datasource/remote/RemoteMatchDataSourceImpl.kt
@@ -19,6 +19,6 @@ class RemoteMatchDataSourceImpl @Inject constructor(
                     dataStore.userId
                 )
             )
-        }.map { it.data }
+        }.mapCatching { it.data }
     }
 }

--- a/core/data/src/main/java/com/moya/funch/datasource/remote/RemoteMemberDataSourceImpl.kt
+++ b/core/data/src/main/java/com/moya/funch/datasource/remote/RemoteMemberDataSourceImpl.kt
@@ -11,6 +11,6 @@ class RemoteMemberDataSourceImpl @Inject constructor(
     override suspend fun fetchMemberProfile(id: String): Result<ProfileModel> {
         return runCatching {
             memberService.findMemberById(id)
-        }.map { it.data.toModel() }
+        }.mapCatching { it.data.toModel() }
     }
 }

--- a/core/data/src/main/java/com/moya/funch/datasource/remote/RemoteUserDataSourceImpl.kt
+++ b/core/data/src/main/java/com/moya/funch/datasource/remote/RemoteUserDataSourceImpl.kt
@@ -19,18 +19,18 @@ class RemoteUserDataSourceImpl @Inject constructor(
 
     private suspend fun fetchUserProfileById(): Result<ProfileModel> {
         return runCatching { memberService.findMemberById(userDataStore.userId).data }
-            .map { it.toModel() }
+            .mapCatching { it.toModel() }
     }
 
     private suspend fun fetchUserProfileByDeviceNumber(): Result<ProfileModel> {
         return runCatching { memberService.findMemberByDeviceNumber(userDataStore.deviceId).data }
-            .map { it.toModel() }
+            .mapCatching { it.toModel() }
     }
 
     override suspend fun createUserProfile(userModel: ProfileModel): Result<ProfileModel> {
         return runCatching {
             val request = userModel.toRequest(userDataStore.deviceId)
             memberService.createMember(request).data
-        }.map { it.toModel() }
+        }.mapCatching { it.toModel() }
     }
 }

--- a/core/data/src/main/java/com/moya/funch/repository/MatchingRepositoryImpl.kt
+++ b/core/data/src/main/java/com/moya/funch/repository/MatchingRepositoryImpl.kt
@@ -9,6 +9,6 @@ class MatchingRepositoryImpl @Inject constructor(
     private val remoteMatchDataSource: RemoteMatchDataSource
 ) : MatchingRepository {
     override suspend fun matchProfile(targetCode: String): Result<Matching> {
-        return remoteMatchDataSource.matchProfile(targetCode).map { it.toDomain() }
+        return remoteMatchDataSource.matchProfile(targetCode).mapCatching { it.toDomain() }
     }
 }

--- a/core/data/src/main/java/com/moya/funch/repository/MemberRepositoryImpl.kt
+++ b/core/data/src/main/java/com/moya/funch/repository/MemberRepositoryImpl.kt
@@ -15,28 +15,29 @@ class MemberRepositoryImpl @Inject constructor(
     override suspend fun fetchUserProfile(): Result<Profile> {
         val profileResult = localUserDataSource.fetchUserProfile()
         if (profileResult.isSuccess) {
-            return profileResult.map { it.toDomain() }
+            return profileResult.mapCatching { it.toDomain() }
         }
+
         return remoteUserDataSource.fetchUserProfile().onSuccess {
             localUserDataSource.saveUserProfile(it)
-        }.map { it.toDomain() }
+        }.mapCatching { it.toDomain() }
     }
 
     override suspend fun createUserProfile(profile: Profile): Result<Profile> {
         return remoteUserDataSource.createUserProfile(profile.toModel())
             .onSuccess {
                 localUserDataSource.saveUserProfile(it)
-            }.map { it.toDomain() }
+            }.mapCatching { it.toDomain() }
     }
 
     override suspend fun fetchUserViewCount(): Result<Int> {
-        return remoteUserDataSource.fetchUserProfile().map {
+        return remoteUserDataSource.fetchUserProfile().mapCatching {
             it.viewCount
         }
     }
 
     override suspend fun fetchMemberProfile(id: String): Result<Profile> {
-        return remoteMemberDataSource.fetchMemberProfile(id).map {
+        return remoteMemberDataSource.fetchMemberProfile(id).mapCatching {
             it.toDomain()
         }
     }

--- a/core/datastore/src/main/java/com/moya/funch/datastore/UserDataStoreImpl.kt
+++ b/core/datastore/src/main/java/com/moya/funch/datastore/UserDataStoreImpl.kt
@@ -108,7 +108,7 @@ class UserDataStoreImpl @Inject constructor(
 
     private fun initDeviceId() {
         if (preferences.contains(DEVICE_ID).not()) {
-            userId = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
+            deviceId = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
         }
     }
 

--- a/core/domain/src/main/java/com/moya/funch/usecase/CanMatchProfileUseCase.kt
+++ b/core/domain/src/main/java/com/moya/funch/usecase/CanMatchProfileUseCase.kt
@@ -9,7 +9,7 @@ class CanMatchProfileUseCaseImpl @Inject constructor(
     override suspend operator fun invoke(targetCode: String): Result<Unit> = runCatching {
         val code = targetCode.uppercase()
         validate(code)
-        matchingRepository.matchProfile(code)
+        matchingRepository.matchProfile(code).getOrThrow()
     }
 
     private fun validate(targetCode: String) {


### PR DESCRIPTION
## 관련 이슈
- closed #이슈넘버

## 작업한 내용
- data모듈 Result.map() -> Result.mapCatching으로 수정
- dataStore DeviceId : USER_ID -> DeviceID로 수정

## 작업 내용 설명
### 1) 
<img  width = "600" src = "https://github.com/Nexters/Funch-AOS/assets/87055456/5f2c6577-a57a-4a59-a9e8-876f1b98e8f9">

Result.map() 함수가 mapping에 실패하면 바로 Exception을 발생시키더라구요.. 그래서 Result.mapCatching()으로 수정했습니다!

### 2)

![image](https://github.com/Nexters/Funch-AOS/assets/87055456/441a2e1e-ce3e-40a4-8996-6f612deb8555)

플젝 초창기 때 device_id 가 아니라 user_id 로 설정했던거 안바꿔서 버그가 납니다...  

![image](https://github.com/Nexters/Funch-AOS/assets/87055456/e50dc20c-d19b-4049-ac20-16fce6ac62ee)  

그리고, 초창기에 내가 test해본다고 mainactivity에서 dataStore에 id preference에 저장했어서 지워줘야합니다!
> LocalUserDataSourceImpl - fetchUserProfile() 부분에 userDataStore.clear() 한번 실행하고 지워주면 됩니다

### 3) 
- CanMatchProfileUseCase 에서  .getOrThrow() 안해주니까 에러가 viewModel 단으로 전파가 안돼서 추가해주었습니당
## 🚀Next Feature
