### PR TITLE
[Feat] 온보딩 화면 연결 및 UX 개선

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     implementation(projects.core.designsystem)
     implementation(projects.core.domain)
     implementation(projects.core.data)
+    implementation(projects.core.datastore)
     // feature
     implementation(projects.feature.profile)
     implementation(projects.feature.home)

--- a/app/src/main/java/com/moya/funch/MainActivity.kt
+++ b/app/src/main/java/com/moya/funch/MainActivity.kt
@@ -9,14 +9,20 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import com.moya.funch.datastore.UserDataStore
 import com.moya.funch.splash.LoadingScreen
 import com.moya.funch.theme.FunchTheme
 import com.moya.funch.ui.FunchApp
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    @Inject
+    lateinit var dataStore: UserDataStore
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         installSplashScreen()
@@ -32,7 +38,7 @@ class MainActivity : ComponentActivity() {
                 if (showLoading) {
                     LoadingScreen()
                 } else {
-                    FunchApp()
+                    FunchApp(dataStore = dataStore)
                 }
             }
         }

--- a/app/src/main/java/com/moya/funch/MainActivity.kt
+++ b/app/src/main/java/com/moya/funch/MainActivity.kt
@@ -14,8 +14,8 @@ import com.moya.funch.splash.LoadingScreen
 import com.moya.funch.theme.FunchTheme
 import com.moya.funch.ui.FunchApp
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.delay
 import javax.inject.Inject
+import kotlinx.coroutines.delay
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {

--- a/app/src/main/java/com/moya/funch/navigation/FunchNavHost.kt
+++ b/app/src/main/java/com/moya/funch/navigation/FunchNavHost.kt
@@ -8,6 +8,8 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navOptions
 import com.moya.funch.match.navigation.matchingScreen
 import com.moya.funch.match.navigation.navigateToMatching
+import com.moya.funch.onboarding.navigation.ON_BOARDING_ROUTE
+import com.moya.funch.onboarding.navigation.onBoardingScreen
 
 @Composable
 fun FunchNavHost(hasProfile: Boolean, navController: NavHostController = rememberNavController()) {
@@ -17,14 +19,15 @@ fun FunchNavHost(hasProfile: Boolean, navController: NavHostController = remembe
     ) {
         with(navController) {
             profileGraph(
-                onNavigateToHome = ::navigateToHome,
-                onCloseMyProfile = ::closeMyProfile
+                onNavigateToHome = ::onNavigateToHome,
+                onCloseMyProfile = ::onCloseMyProfile
             )
             homeScreen(
                 onNavigateToMatching = ::onNavigateToMatching,
                 onNavigateToMyProfile = ::onNavigateToMyProfile
             )
             matchingScreen(onClose = { popBackStack(HOME_ROUTE, false) })
+            onBoardingScreen(onNavigateToCreateProfile = ::navigateToCreateProfile)
         }
     }
 }
@@ -39,5 +42,5 @@ private val singleTopNavOptions = navOptions {
 }
 
 private fun determineStartDestination(hasProfile: Boolean): String {
-    return if (hasProfile) HOME_ROUTE else PROFILE_GRAPH_ROUTE
+    return if (hasProfile) HOME_ROUTE else ON_BOARDING_ROUTE
 }

--- a/app/src/main/java/com/moya/funch/ui/FunchApp.kt
+++ b/app/src/main/java/com/moya/funch/ui/FunchApp.kt
@@ -4,11 +4,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import com.moya.funch.datastore.UserDataStore
 import com.moya.funch.navigation.FunchNavHost
 import com.moya.funch.theme.LocalBackgroundTheme
 
 @Composable
-fun FunchApp() {
+fun FunchApp(dataStore: UserDataStore) {
     val backgroundColor = LocalBackgroundTheme.current.color
 
     Surface(
@@ -16,7 +17,7 @@ fun FunchApp() {
         color = backgroundColor
     ) {
         FunchNavHost(
-            hasProfile = false
+            hasProfile = dataStore.hasUserId()
         )
     }
 }

--- a/core/designsystem/src/main/java/com/moya/funch/component/Chip.kt
+++ b/core/designsystem/src/main/java/com/moya/funch/component/Chip.kt
@@ -166,7 +166,6 @@ data class PunchChipColors(
     private val selectedLabelColor: Color = White,
     private val disabledLabelColor: Color = Gray400,
     private val disabledSelectedLabelColor: Color = White
-    // private val
 ) {
     @Stable
     fun provideContainerColor(enabled: Boolean, selected: Boolean): Color {

--- a/core/designsystem/src/main/java/com/moya/funch/theme/Theme.kt
+++ b/core/designsystem/src/main/java/com/moya/funch/theme/Theme.kt
@@ -35,6 +35,7 @@ private fun statusBar() {
         SideEffect {
             val window = (view.context as Activity).window
             window.statusBarColor = Gray900.toArgb()
+            window.navigationBarColor = Gray900.toArgb()
         }
     }
 }

--- a/feature/home/src/main/java/com/moya/funch/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/java/com/moya/funch/navigation/HomeNavigation.kt
@@ -7,7 +7,7 @@ import com.moya.funch.HomeRoute
 
 const val HOME_ROUTE = "home"
 
-fun NavController.navigateToHome() = navigate(HOME_ROUTE) {
+fun NavController.onNavigateToHome() = navigate(HOME_ROUTE) {
     popUpTo(graph.id)
 }
 

--- a/feature/onboarding/src/main/java/com/moya/funch/onboarding/navigation/OnBoardingNavigation.kt
+++ b/feature/onboarding/src/main/java/com/moya/funch/onboarding/navigation/OnBoardingNavigation.kt
@@ -4,10 +4,10 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.moya.funch.onboarding.OnBoardingScreen
 
-const val ON_BOARDING_ROUTE = "home"
+const val ON_BOARDING_ROUTE = "on_boarding"
 
 fun NavGraphBuilder.onBoardingScreen(onNavigateToCreateProfile: () -> Unit) {
     composable(route = ON_BOARDING_ROUTE) {
-        OnBoardingScreen(onNavigateToCreateProfile)
+        OnBoardingScreen(onNavigateToCreateProfile = onNavigateToCreateProfile)
     }
 }

--- a/feature/profile/src/main/java/com/moya/funch/CreatePofileViewModel.kt
+++ b/feature/profile/src/main/java/com/moya/funch/CreatePofileViewModel.kt
@@ -113,7 +113,7 @@ internal class CreateProfileViewModel @Inject constructor(
                     onSuccess = { response ->
                         val newState = when {
                             response.isEmpty() -> SubwayTextFieldState.Error
-                            response.size == 1 && subway == response.first().name -> SubwayTextFieldState.Success
+                            subway == response.first().name -> SubwayTextFieldState.Success
                             else -> SubwayTextFieldState.Typing
                         }
                         setSubwayStations(response)

--- a/feature/profile/src/main/java/com/moya/funch/CreateProflieScreen.kt
+++ b/feature/profile/src/main/java/com/moya/funch/CreateProflieScreen.kt
@@ -479,8 +479,10 @@ private fun SubwayRow(
     val isFocused by interactionSource.collectIsFocusedAsState()
     val focusManager = LocalFocusManager.current
 
-    LaunchedEffect(subwayStation) {
-        scrollState.animateScrollTo(scrollState.maxValue)
+    if (isFocused) {
+        LaunchedEffect(subwayStation) {
+            scrollState.animateScrollTo(scrollState.maxValue)
+        }
     }
 
     Row {

--- a/feature/profile/src/main/java/com/moya/funch/CreateProflieScreen.kt
+++ b/feature/profile/src/main/java/com/moya/funch/CreateProflieScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
@@ -278,7 +279,11 @@ private fun NicknameRow(nickname: String, onNicknameChange: (String) -> Unit, is
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
-private fun JobRow(profile: ProfileUiModel, onSelected: (Job) -> Unit) {
+private fun JobRow(
+    profile: ProfileUiModel,
+    onSelected: (Job) -> Unit,
+    focusManager: FocusManager = LocalFocusManager.current
+) {
     Row {
         FunchSmallLabel(text = ProfileLabel.JOB.labelName)
         FlowRow(
@@ -290,7 +295,10 @@ private fun JobRow(profile: ProfileUiModel, onSelected: (Job) -> Unit) {
                 FunchChip(
                     selected = profile.job == job,
                     enabled = true,
-                    onSelected = { onSelected(job) },
+                    onSelected = {
+                        onSelected(job)
+                        focusManager.clearFocus()
+                    },
                     label = {
                         Text(
                             text = job.krName,
@@ -324,7 +332,7 @@ private fun JobRow(profile: ProfileUiModel, onSelected: (Job) -> Unit) {
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
-private fun ClubRow(onSelectClub: (Club) -> Unit) {
+private fun ClubRow(onSelectClub: (Club) -> Unit, focusManager: FocusManager = LocalFocusManager.current) {
     Row {
         FunchSmallLabel(text = ProfileLabel.CLUB.labelName)
         FlowRow(
@@ -338,6 +346,7 @@ private fun ClubRow(onSelectClub: (Club) -> Unit) {
                     selected = isSelected,
                     enabled = true,
                     onSelected = {
+                        focusManager.clearFocus()
                         onSelectClub(club)
                         isSelected = !isSelected
                     },
@@ -373,7 +382,11 @@ private fun ClubRow(onSelectClub: (Club) -> Unit) {
 }
 
 @Composable
-private fun MbtiRow(profile: ProfileUiModel, onSelectMbti: (MbtiItem) -> Unit) {
+private fun MbtiRow(
+    profile: ProfileUiModel,
+    onSelectMbti: (MbtiItem) -> Unit,
+    focusManager: FocusManager = LocalFocusManager.current
+) {
     val eOrI = profile.eOrI
     val nOrS = profile.nOrS
     val tOrF = profile.tOrF
@@ -397,6 +410,7 @@ private fun MbtiRow(profile: ProfileUiModel, onSelectMbti: (MbtiItem) -> Unit) {
                             mbtiItem = mbti,
                             isSelected = currentMbti[i] == mbti,
                             onSelected = {
+                                focusManager.clearFocus()
                                 onSelectMbti(it)
                             }
                         )
@@ -433,7 +447,7 @@ private fun MbtiButton(mbtiItem: MbtiItem, isSelected: Boolean, onSelected: (Mbt
 }
 
 @Composable
-private fun BooldTypeRow(onSelectBloodType: (Blood) -> Unit) {
+private fun BooldTypeRow(onSelectBloodType: (Blood) -> Unit, focusManager: FocusManager = LocalFocusManager.current) {
     val bloodTypes = Blood.entries.filterNot { it == Blood.IDLE }.map { it.type }
     var placeHolder by remember { mutableStateOf(bloodTypes[0]) }
     var isDropDownMenuExpanded by remember { mutableStateOf(false) }
@@ -444,7 +458,10 @@ private fun BooldTypeRow(onSelectBloodType: (Blood) -> Unit) {
         Box {
             FunchDropDownButton(
                 placeHolder = placeHolder,
-                onClick = { isDropDownMenuExpanded = !isDropDownMenuExpanded },
+                onClick = {
+                    focusManager.clearFocus()
+                    isDropDownMenuExpanded = !isDropDownMenuExpanded
+                },
                 isDropDownMenuExpanded = isDropDownMenuExpanded,
                 indication = null,
                 modifier = Modifier.onGloballyPositioned { coordinates ->

--- a/feature/profile/src/main/java/com/moya/funch/navigation/MyProfileNavigatoin.kt
+++ b/feature/profile/src/main/java/com/moya/funch/navigation/MyProfileNavigatoin.kt
@@ -13,7 +13,10 @@ const val PROFILE_GRAPH_ROUTE = "profile_graph"
 fun NavController.navigateToMyProfile(navOptions: NavOptions? = null) =
     navigate(ProfileScreens.MyProfile.route, navOptions)
 
-fun NavController.closeMyProfile() = popBackStack()
+fun NavController.navigateToCreateProfile(navOptions: NavOptions? = null) =
+    navigate(ProfileScreens.Create.route, navOptions)
+
+fun NavController.onCloseMyProfile() = popBackStack()
 
 fun NavGraphBuilder.profileGraph(onNavigateToHome: () -> Unit, onCloseMyProfile: () -> Unit) {
     navigation(


### PR DESCRIPTION
## 관련 이슈
- closed #39 
- closed #79 

## 작업한 내용
- 온보딩-프로필 생성 화면을 연결하였습니다.
- 프로필 생성 UX를 개선하였습니다.

## PR 포인트
- 프로필 생성 페이지
  - 지하철 텍스트필드에 값을 입력할 시 최하단으로 스크롤이 됩니다.
  - 키패드가 올라와 있는상태에서 다른 아이콘을 선택하면 키패드가 내려갑니다.
- 시스템 네비게이션바 컬러가 변경되었습니다.
- 온보딩과 프로필 생성 페이지가 연결되었습니다.
- MainActivity에서 UserDataStore에 접근하여 hasUserId()를 통해 프로필 생성 여부를 판단합니다.
  - 이제 프로필이 존재할 시 바로 홈 화면으로 접근합니다.

## 🚀Next Feature
- 1차 릴리즈